### PR TITLE
Quality fixes

### DIFF
--- a/Shaders/basic_specgloss.fs
+++ b/Shaders/basic_specgloss.fs
@@ -11,6 +11,7 @@ in vec3 out_tangent;
 in vec3 out_binormal;
 in vec2 out_texcoord;
 in vec3 out_worldpos;
+in vec3 out_to_camera;
 
 uniform float specular_shininess;
 uniform vec4 color_ambient;
@@ -36,7 +37,7 @@ out vec4 frag_color;
 
 float calculate_specular( vec3 normal, vec3 light_direction )
 {
-  vec3 V = normalize( camera_position - out_worldpos );
+  vec3 V = normalize( out_to_camera );
   vec3 L = -normalize( light_direction );
   vec3 H = normalize( V + L );
   float rdotv = clamp( dot( normal, H ), 0.0, 1.0 );

--- a/Shaders/basic_specgloss.vs
+++ b/Shaders/basic_specgloss.vs
@@ -11,9 +11,12 @@ out vec3 out_tangent;
 out vec3 out_binormal;
 out vec2 out_texcoord;
 out vec3 out_worldpos;
+out vec3 out_viewpos;
+out vec3 out_to_camera;
 
 uniform mat4x4 mat_projection;
 uniform mat4x4 mat_view;
+uniform mat4x4 mat_view_inverse;
 uniform mat4x4 mat_world;
 
 void main()
@@ -22,9 +25,14 @@ void main()
   o = mat_world * o;
   out_worldpos = o.xyz;
   o = mat_view * o;
+  out_viewpos = o.xyz;
+
+  vec3 to_camera = normalize( -o.xyz );
+  out_to_camera = mat3( mat_view_inverse ) * to_camera;
+
   o = mat_projection * o;
   gl_Position = o;
-  
+
   out_normal = normalize( mat3( mat_world ) * in_normal );
   out_tangent = normalize( mat3( mat_world ) * in_tangent );
   out_binormal = normalize( mat3( mat_world ) * in_binormal );

--- a/Shaders/pbr.fs
+++ b/Shaders/pbr.fs
@@ -18,6 +18,7 @@ in vec3 out_tangent;
 in vec3 out_binormal;
 in vec2 out_texcoord;
 in vec3 out_worldpos;
+in vec3 out_to_camera;
 
 uniform vec4 color_ambient;
 uniform vec4 color_diffuse;
@@ -197,7 +198,7 @@ vec3 specular_ibl( vec3 V, vec3 N, float roughness, vec3 fresnel )
   // to avoid black pixels.
   if (use_wraparound_specular)
   {
-    NdotV = NdotV * 0.8 + 0.2;
+    NdotV = NdotV * 0.9 + 0.1;
   }
 
   NdotV = min(0.99, max(0., NdotV));
@@ -249,7 +250,7 @@ void main(void)
   normal = normalize( normal );
 
   vec3 N = normal;
-  vec3 V = normalize( camera_position - out_worldpos );
+  vec3 V = normalize( out_to_camera );
 
   vec3 Lo = vec3(0.);
   vec3 F0 = vec3(0.04);

--- a/Shaders/pbr.fs
+++ b/Shaders/pbr.fs
@@ -6,6 +6,8 @@ const bool use_bruteforce_irradiance = false;
 const bool use_wraparound_specular = true;
 // Dampens IBL specular ambient with AO if enabled.
 const bool use_specular_ao_attenuation = true;
+// Increases roughness if normal map has variation and was minified.
+const bool use_normal_variation_to_roughness = true;
 
 struct Light
 {
@@ -235,7 +237,10 @@ void main(void)
   else if ( has_tex_ambient )
     ao = texture( tex_ambient, out_texcoord ).x;
 
-  vec3 normalmap = normalize(texture( tex_normals, out_texcoord ).xyz * vec3(2.0) - vec3(1.0));
+  vec3 normalmap = texture( tex_normals, out_texcoord ).xyz * vec3(2.0) - vec3(1.0);
+  float normalmap_mip = textureQueryLod( tex_normals, out_texcoord ).x;
+  float normalmap_length = length(normalmap);
+  normalmap /= normalmap_length;
 
   vec3 normal = out_normal;
 
@@ -248,6 +253,15 @@ void main(void)
   }
 
   normal = normalize( normal );
+
+  if (use_normal_variation_to_roughness)
+  {
+    // Try to reduce specular aliasing by increasing roughness when minified normal maps have high variation.
+    float variation = 1. - pow( normalmap_length, 8. );
+    float minification = clamp( normalmap_mip - 2., 0., 1. );
+    roughness = mix( roughness, 1.0, variation * minification );
+  }
+
 
   vec3 N = normal;
   vec3 V = normalize( out_to_camera );

--- a/Shaders/pbr.vs
+++ b/Shaders/pbr.vs
@@ -12,9 +12,11 @@ out vec3 out_binormal;
 out vec2 out_texcoord;
 out vec3 out_worldpos;
 out vec3 out_viewpos;
+out vec3 out_to_camera;
 
 uniform mat4x4 mat_projection;
 uniform mat4x4 mat_view;
+uniform mat4x4 mat_view_inverse;
 uniform mat4x4 mat_world;
 
 void main()
@@ -24,6 +26,10 @@ void main()
   out_worldpos = o.xyz;
   o = mat_view * o;
   out_viewpos = o.xyz;
+
+  vec3 to_camera = normalize( -o.xyz );
+  out_to_camera = mat3( mat_view_inverse ) * to_camera;
+
   o = mat_projection * o;
   gl_Position = o;
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -614,6 +614,7 @@ int main( int argc, const char * argv[] )
 
     viewMatrix = glm::lookAtRH( cameraPosition + gCameraTarget, gCameraTarget, glm::vec3( 0.0f, 1.0f, 0.0f ) );
     gCurrentShader->SetConstant( "mat_view", viewMatrix );
+    gCurrentShader->SetConstant( "mat_view_inverse", glm::inverse( viewMatrix ) );
 
     gCurrentShader->SetConstant( "has_tex_skysphere", gSkyImages.reflection != NULL );
     gCurrentShader->SetConstant( "has_tex_skyenv", gSkyImages.env != NULL );


### PR DESCRIPTION
- Compute view vector in vertex shader
- Increase roughness if normal map was minified (its LOD was > 0) and had variation (normalmap vector length < 1.0)

Here's how the variation hack works:
![normal_variation_to_roughness](https://user-images.githubusercontent.com/934568/108597763-69f54300-7393-11eb-8742-34cff45c0940.gif)

There's a "proper" way to do it via VMF lobes https://graphicrants.blogspot.com/2018/05/normal-map-filtering-using-vmf-part-3.html but it's still not 100% correct for GGX normal distribution function so it may not look better anyway.
