### PR TITLE
Translucency support

### DIFF
--- a/Shaders/basic_specgloss.fs
+++ b/Shaders/basic_specgloss.fs
@@ -126,5 +126,5 @@ void main(void)
 
   color += sample_colormap( map_emissive, out_texcoord ).rgb;
 
-  frag_color = vec4( pow( color * exposure, vec3(1. / 2.2) ), alpha.w );
+  frag_color = vec4( pow( color * exposure, vec3(1. / 2.2) ), alpha );
 }

--- a/Shaders/basic_specgloss.fs
+++ b/Shaders/basic_specgloss.fs
@@ -95,7 +95,9 @@ float calculate_specular( vec3 normal, vec3 light_direction )
 void main(void)
 {
   vec3 ambient = sample_colormap( map_ambient, out_texcoord ).xyz;
-  vec3 diffusemap = sample_colormap( map_diffuse, out_texcoord ).xyz;
+  vec4 diffusemap_alpha = sample_colormap( map_diffuse, out_texcoord );
+  vec3 diffusemap = diffusemap_alpha.xyz;
+  float alpha = diffusemap_alpha.w;
   vec3 normalmap = normalize(texture( map_normals.tex, out_texcoord ).xyz * vec3(2.0) - vec3(1.0));
   vec4 specularmap = sample_colormap( map_specular, out_texcoord );
 
@@ -124,5 +126,5 @@ void main(void)
 
   color += sample_colormap( map_emissive, out_texcoord ).rgb;
 
-  frag_color = vec4( pow( color * exposure, vec3(1. / 2.2) ), 1.0f );
+  frag_color = vec4( pow( color * exposure, vec3(1. / 2.2) ), alpha.w );
 }

--- a/Shaders/pbr.fs
+++ b/Shaders/pbr.fs
@@ -341,7 +341,7 @@ void main(void)
       kD *= 1.0 - metallic;
 
 	  // Premultiplied alpha applied to the diffuse component only
-	  kD *= alpha
+	  kD *= alpha;
 
       float D = distribution_ggx( N, H, roughness );
       float G = geometry_smith( N, V, L, roughness );
@@ -393,7 +393,7 @@ void main(void)
     kD *= 1.0 - metallic;
 
     // Premultiplied alpha applied to the diffuse component only
-    kD *= alpha
+    kD *= alpha;
 
     // Modulate the incoming lighting with the diffuse color: some wavelengths get absorbed.
     diffuse_ambient = irradiance * baseColor;

--- a/Shaders/pbr.fs
+++ b/Shaders/pbr.fs
@@ -191,7 +191,7 @@ vec3 sample_irradiance_fast( vec3 normal, vec3 vertex_tangent )
   // Sample the irradiance map if it exists, otherwise fall back to blurred reflection map.
   if ( has_tex_skyenv )
   {
-    vec2 polar = sphere_to_polar_clamp_y( normal );
+    vec2 polar = sphere_to_polar_clamp_y( normal, 180.0 );
     // HACK: Sample a smaller mip here to avoid high frequency color variations on detailed normal
     //       mapped areas.
     // float miplevel = 5.5; // tweaked for a 360x180 irradiance texture
@@ -261,7 +261,7 @@ void main(void)
   float ao = 1.0;
   float alpha = 1.0;
 
-  vec4 baseColor_Alpha;
+  vec4 baseColor_alpha;
   if ( map_albedo.has_tex )
     baseColor_alpha = sample_colormap( map_albedo, out_texcoord );
   else

--- a/Shaders/pbr.fs
+++ b/Shaders/pbr.fs
@@ -136,6 +136,15 @@ vec2 sphere_to_polar( vec3 normal )
   return vec2( ( atan( normal.z, normal.x ) + skysphere_rotation ) / PI / 2.0 + 0.5, acos( normal.y ) / PI );
 }
 
+// Our vertically GL_CLAMPed textures seem to blend towards black when sampling the half-pixel edge.
+// Not sure if it has a border, or this if is a driver bug, but can repro on multiple nvidia cards.
+// Knowing the texture height we can limit sampling to the centers of the top and bottom pixel rows.
+vec2 sphere_to_polar_clamp_y( vec3 normal, float texture_height )
+{
+  normal = normalize( normal );
+  return vec2( ( atan( normal.z, normal.x ) + skysphere_rotation ) / PI / 2.0 + 0.5, clamp(acos( normal.y ) / PI, 0.5 / texture_height, 1.0 - 0.5 / texture_height) );
+}
+
 vec3 sample_sky( vec3 normal )
 {
   vec2 polar = sphere_to_polar( normal );
@@ -182,10 +191,12 @@ vec3 sample_irradiance_fast( vec3 normal, vec3 vertex_tangent )
   // Sample the irradiance map if it exists, otherwise fall back to blurred reflection map.
   if ( has_tex_skyenv )
   {
-    vec2 polar = sphere_to_polar( normal );
+    vec2 polar = sphere_to_polar_clamp_y( normal );
     // HACK: Sample a smaller mip here to avoid high frequency color variations on detailed normal
     //       mapped areas.
-    float miplevel = 5.5; // tweaked for a 360x180 irradiance texture
+    // float miplevel = 5.5; // tweaked for a 360x180 irradiance texture
+	// ^ unhacked because the mip higher levels cause really weird shading around poles, try a diffuse sphere to see what I mean!
+	float miplevel = 0.0;
     return textureLod( tex_skyenv, polar, miplevel ).rgb * exposure;
   }
   else

--- a/data/windows/SetupDialog.rc
+++ b/data/windows/SetupDialog.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "winres.h"
+#include "afxres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -71,7 +71,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""winres.h""\r\n"
+    "#include ""afxres.h""\r\n"
     "\0"
 END
 

--- a/data/windows/SetupDialog.rc
+++ b/data/windows/SetupDialog.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -71,7 +71,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -64,7 +64,7 @@ Renderer::Texture * LoadTexture( const char * _type, const aiString & _path, con
 
   printf( "[geometry] Loading %s texture: '%s'\n", _type, filename.c_str() );
 
-  Renderer::Texture * texture = Renderer::CreateRGBA8TextureFromFile( filename.c_str() );
+  Renderer::Texture * texture = Renderer::CreateRGBA8TextureFromFile( filename.c_str(), _loadAsSRGB );
   if ( texture )
   {
     return texture;

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -110,7 +110,8 @@ bool LoadColorMap( aiMaterial * _material, Geometry::ColorMap & _colorMap, aiTex
   }
 
   aiColor4D color;
-  aiReturn result = AI_FAILURE;
+  aiColor4D translucentColor;
+  aiReturn result = AI_FAILURE, result2 = AI_FAILURE;
   switch ( _semantic )
   {
     case aiTextureType_AMBIENT:
@@ -119,9 +120,15 @@ bool LoadColorMap( aiMaterial * _material, Geometry::ColorMap & _colorMap, aiTex
     case aiTextureType_DIFFUSE:
     case aiTextureType_BASE_COLOR:
       result = aiGetMaterialColor( _material, AI_MATKEY_COLOR_DIFFUSE, &color );
+      result2 = aiGetMaterialColor(_material, AI_MATKEY_COLOR_TRANSPARENT, &translucentColor);
+      if (result2 == AI_SUCCESS)
+        color.a = (1.0 - translucentColor.r);
       break;
     case aiTextureType_SPECULAR:
       result = aiGetMaterialColor( _material, AI_MATKEY_COLOR_SPECULAR, &color );
+      break;
+    case aiTextureType_EMISSIVE:
+      result = aiGetMaterialColor(_material, AI_MATKEY_COLOR_EMISSIVE, &color);
       break;
   };
   if ( result == AI_SUCCESS )

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -32,6 +32,8 @@ public:
 
     glm::vec3 mAABBMin;
     glm::vec3 mAABBMax;
+
+    bool mTransparent;
   };
   struct ColorMap
   {

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -36,6 +36,7 @@ struct Texture
   std::string mFilename;
   unsigned int mGLTextureID;
   int mGLTextureUnit;
+  bool mTransparent;
 };
 
 struct Shader


### PR DESCRIPTION
You want to ignore resource.rc changes, and possibly you don't want the changes from 6ff7230.
Most risky change is the emissive & alpha reading code, only tested with Maya fbx exports at this point.
